### PR TITLE
remove zope to fix compatibility with Certbot 2.x

### DIFF
--- a/certbot_dns_netcup.py
+++ b/certbot_dns_netcup.py
@@ -10,17 +10,13 @@ __url__     = 'https://github.com/coldfix/certbot-dns-netcup'
 __all__     = ['Authenticator']
 
 from lexicon.providers import netcup
-import zope.interface
 
-from certbot import interfaces
 from certbot.plugins import dns_common
 from certbot.plugins import dns_common_lexicon
 
 CCP_API_URL = 'https://www.netcup-wiki.de/wiki/CCP_API'
 
 
-@zope.interface.implementer(interfaces.IAuthenticator)
-@zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(dns_common.DNSAuthenticator):
     """DNS Authenticator for netcup
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,6 @@ install_requires =
     acme>=0.31.0
     certbot>=0.31.0
     dns-lexicon>=3.2.3
-    zope.interface
 
 [options.entry_points]
 certbot.plugins =


### PR DESCRIPTION
based on https://github.com/helgeerbe/certbot-dns-ionos/commit/c12f443c15002f2b2dccd1818711079620482c49

fixes https://github.com/coldfix/certbot-dns-netcup/issues/17