### PR TITLE
Prepare for certbot >= v3.0.0, migrate from snap core20 to core24

### DIFF
--- a/certbot_dns_netcup.py
+++ b/certbot_dns_netcup.py
@@ -5,7 +5,7 @@ removing, TXT records using the netcup CCP API.
 """
 
 # Keep metadata before any imports (for setup.py)!
-__version__ = '1.4.3'
+__version__ = '3.0.0'
 __url__     = 'https://github.com/coldfix/certbot-dns-netcup'
 __all__     = ['Authenticator']
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: certbot-dns-netcup
-version: 1.4.3
+version: 3.0.0
 summary: Certbot DNS Authenticator plugin for netcup
 description: |
   This plugin automates the process of completing a dns-01 challenge by
@@ -8,10 +8,12 @@ description: |
 
 confinement: strict
 grade: stable
-base: core20
-architectures:
-  - build-on: amd64
-    run-on: all
+base: core24
+adopt-info: certbot-dns-netcup
+platforms:
+  all:
+    build-on: amd64
+    build-for: all
 
 parts:
   certbot-dns-netcup:
@@ -47,10 +49,24 @@ parts:
       rm -rf $VENV_BASE_PACKAGES
     prime:
       - lib
+  certbot-metadata:
+    plugin: dump
+    source: .
+    stage: [setup.py, certbot-shared]
+    override-pull: |
+        craftctl default
+        mkdir -p $SNAPCRAFT_PART_SRC/certbot-shared
 
 slots:
   certbot:
     interface: content
     content: certbot-1
     read:
-      - $SNAP/lib/python3.8/site-packages
+      - $SNAP/lib/python3.12/site-packages
+
+plugs:
+  certbot-metadata:
+    interface: content
+    content: metadata-1
+    target: $SNAP/certbot-shared
+


### PR DESCRIPTION
Currently, certbot-dns-netcup is not compatible with certbot version >= `3.0.0`. Executing certbot results in the following error message:

```text
root@hostname:/# certbot --version
The following plugins are using an outdated python version and must be updated to be compatible with Certbot 3.0. Please see https://community.letsencrypt.org/t/certbot-3-0-could-have-potential-third-party-snap-breakages/226940 for more information:
  * certbot-dns-netcup
certbot 3.0.1

```

This PR contains the changes proposed in #35 to make this plugin compatible with the current certbot version.

A build using snapcraft `v8.4.4` with `core24` succeeded. However, I never worked with snap before so please cross check my changes!